### PR TITLE
Update requirements for Flarum beta 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "source": "https://github.com/Fajuu/flarum-icons"
   },
   "require": {
-    "flarum/core": ">=0.1.0-beta.10 <0.1.0-beta.12"
+    "flarum/core": ">=0.1.0-beta.10 <0.1.0-beta.14"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
I have tested the extension on beta 13 and it's fully compatible. Only the composer requirement need to be changed to enable installation on beta 13.

You can merge my PR, or just make the change yourself on master.